### PR TITLE
Add gov.uk list of register offices

### DIFF
--- a/lists/gov-uk/register-offices.tsv
+++ b/lists/gov-uk/register-offices.tsv
@@ -1,0 +1,583 @@
+name	address1	address2	address3	postcode	url
+Abergavenny Register Office	Coed Glas	Abergavenny		NP7 5LE	http://www.monmouthshire.gov.uk/research-your-family-history
+Abergavenny Sub Office	Nevill Hall Hospital	Brecon Road	Abergavenny	NP7 7EG	http://www.monmouthshire.gov.uk/research-your-family-history
+Abingdon Register Office	Roysse Court	Bridge Street	Abingdon	OX14 3HU	https://www.oxfordshire.gov.uk/cms/content/registration-offices
+Accrington Register Office	The Mechanics Institute	Willow Street	Accrington	BB5 1LP	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/accrington-registration-office.aspx
+Aldershot Registration Office	30 Grosvenor Road	Aldershot		GU11 3EB	http://www3.hants.gov.uk/registration/registrationfinder/ro-aldershot.htm
+Alnwick Register Office	27 Fenkle Street	Alnwick		NE66 1HW	http://www.northumberland.gov.uk/Registration.aspx
+Alton Registration Office	4 Queens Road	Alton		GU34 1HU	http://www3.hants.gov.uk/registration/registrationfinder/ro-alton.htm
+Amber Valley Registration Office	Town Hall	Market Place	Ripley	DE5 3BT	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Amble Register Office	73 Queen Street	Amble	Morpeth	NE65 0DA	http://www.northumberland.gov.uk/Registration.aspx
+Ammanford Register Office	3b Wind Street	Ammanford	Dyfed	SA18 3DN	http://www.carmarthenshire.gov.wales/home/residents/births-deaths-marriages/
+Ampthill Register Office	The Court House	Woburn Street	Ampthill	MK45 2HX	http://www.centralbedfordshire.gov.uk/registration/landing.aspx
+Andover Registration Office	Weyhill Road		Andover	SP103AJ	http://www3.hants.gov.uk/registration/registrationfinder/ro-andover.htm
+Armley One Stop Centre	2 Stocks Hill	Armley	Leeds	LS12 1UQ	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Ashbourne Registration Office	Ashbourne Library	2 Compton	Ashbourne	DE6 1DA	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Ashfield District Council Offices	Watnall Road	Hucknall	Nottingham	NG15 7LA	http://www.nottinghamshire.gov.uk/births-deaths-marriages-and-civil-partnerships/register-offices-and-fees/nottinghamshire-register-offices/hucknall-registration-office
+Ashford Register Office	 Ashford Gateway	Church Road	Ashford	TN23 1AS	http://www.kent.gov.uk/about-the-council/contact-us/gateway/ashford-gateway-plus
+Ashington Register Office	Post Office Chambers	Station Road	Ashington	NE63 8RH	http://www.northumberland.gov.uk/Registration.aspx
+Atherstone Registration Office	North Warwickshire Borough Council	South Street	Atherstone	CV9 1DE	http://www.warwickshire.gov.uk/registrationoffices
+Bakewell Registration Office	Town Hall	Bakewell		DE45 1BW	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Banbury Register Office	Bodictote House	Banbury		OX15 4AA	https://www.oxfordshire.gov.uk/cms/content/registration-offices
+Bangor Register Office	Town Hall	Bangor		LL57 2RE	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Barking and Dagenham Register Office	Woodlands House	Rainham Road North	Dagenham	RM10 7ER	https://www.lbbd.gov.uk/residents/births-marriages-deaths-and-nationality/
+Barnard Castle Register Office	30 Galgate	Barnard Castle	County Durham	DL12 8BH	http://www.durham.gov.uk/registeroffices
+Barnsley Register Office	Town Hall	Barnsley		S70 2TA	http://www.barnsley.gov.uk/contacting-the-register-office
+Barrow Register Office	Nan Tait Centre	Abbey Road	Barrow In Furness	LA14 1LG	http://www.cumbria.gov.uk/registrationservice/local_register_offices/barrow.asp
+Basford Registration Office	Highbury Road	Bulwell	Nottingham	NG6 9DA	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Basildon Registration Office	Basildon Library	St Martin's Square	Basildon	SS14 1DL	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Basingstoke Registration Office	Goldings	London Road	Basingstoke	RG21 4AN	http://www3.hants.gov.uk/registration/registrationfinder/ro-basingstoke.htm
+Beaconsfield Old Town Registration Office	29 Windsor End		Beaconsfield	HP9 2JJ	http://www.buckscc.gov.uk/community/births,-deaths,-marriages-and-civil-partnerships/register-offices/beaconsfield/
+Bedford Register Office	Old Town Hall	St. Pauls Square	Bedford	MK40 1SQ	http://www.centralbedfordshire.gov.uk/registration/landing.aspx
+Bedworth Registration Office	Kings House	King Street	Bedworth	CV12 8LL	http://www.warwickshire.gov.uk/registrationoffices
+Beeston Register Office	Beeston Library, Foster Avenue	Beeston	Nottingham	NG9 1AE	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Berkshire Register Office	Civic Offices, Shute End	Wokingham	Berkshire	RG40 1WH	http://www.wokingham.gov.uk/births-deaths-and-marriages/
+Berwick Register Office	Berwick Community Centre	5 Palace Street East	Berwick-upon-Tweed	TD15 1HT	http://www.northumberland.gov.uk/Registration.aspx
+Beverley Registration Office	Walkergate House	Walkergate	Beverley	HU17 9BP	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Bexley Register Office	Danson House, Danson Park	Bexleyheath	Kent	DA6 8HL	http://www.bexley.gov.uk/article/318/Marriages-and-civil-partnerships
+Bicester Register Office	The Garth	Launton Road	Bicester	OX26 6PS	https://www.oxfordshire.gov.uk/cms/content/registration-offices
+Biggleswade Register Office	The Limes	142 London Road	Biggleswade	SG18 8EL	http://www.centralbedfordshire.gov.uk/registration/landing.aspx
+Billericay Registration Office	Burghstead Lodge	143 High Street	Billericay	CM12 9AB	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Bingham Register Office	The Court House, Church Street	Bingham	Nottingham	NG13 8AL	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Birkenhead Register Office	Town Hall	Mortimer Street	Birkenhead	CH41 5EU	http://www.wirral.gov.uk/my-services/find-us/council-offices/wirral-register-office
+Birmingham Register Office	Holliday Wharf	Holliday Street	Birmingham	B1 1TJ	http://www.birmingham.gov.uk/registeroffice
+Bishop Auckland Register Office	Cockton House	35 Cockton Hill Road	Bishop Auckland	DL14 6HS	http://www.durham.gov.uk/registeroffices
+Bishops Castle Register Office	Enterprise House	Station Street	Bishops Castle	SY9 5AQ	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Bishops Stortford Registration Office	Riverside House	2 Hockerhill Street	Bishops Stortford	CM23 2DL	http://www.hertsdirect.org/your-community/register/contactreg/bishopsreg
+Blackburn Register Office	King Georges Hall	Northgate	Blackburn	BB2 1AA	https://www.blackburn.gov.uk/Pages/Register-offices.aspx
+Blackpool Register Office	Festival House	Promenade	Blackpool	FY1 1AP	http://www.blackpool.gov.uk/Residents/Life-events/Life-events.aspx
+Blacon Library Register Office	Blacon Library, Western Avenue	Blacon	Chester	CH1 5QY	http://www.cheshirewestandchester.gov.uk/residents/births,_deaths_and_marriage/contact_and_opening_hours.aspx
+Blaenau Ffestiniog Outstation	The Library, Canolfan	Maenofferen	Blaenau Ffestiniog	LL41 3DL	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Blaenavon Customer Care Centre	Lion Court	Lion Street	Blaenavon	NP4 9QA	http://www.torfaen.gov.uk/en/BirthsDeathsCeremonies/Registration-Opening-Hours-and-Locations/Hours-and-Locations.aspx
+Blandford Registration Office	Norden	Salisbury Road	Blandford Forum	DT11 7LN	http://www.dorsetforyou.com/374463
+Bodmin Registration Office	Lyndhurst	66 St Nicholas Street	Bodmin	PL31 1AG	http://www.cornwall.gov.uk/Default.aspx?page=14491
+Bognor Regis Register Office	Durban House, South Bersted Business Park	Durban Road	Bognor Regis	PO22 9RE	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Bolton Register Office	Mere Hall, Merehall Street	Bolton	Lancashire	BL1 2QT	http://www.bolton.gov.uk/website/Pages/Birthsmarriagesanddeaths.aspx
+Boston Registration Office	Boston Borough Council Offices, Municipal Buildings	West Street	Boston	PE21 8QR	http://www.lincolnshire.gov.uk/residents/births-marriages-deaths-and-civil-partnerships/registration-offices/boston-registration-office/28775.article
+Bourne Registration Office	Saxonhurst	35 West Street	Bourne	PE10 9NE	http://www.lincolnshire.gov.uk/residents/births-marriages-deaths-and-civil-partnerships/registration-offices/bourne-registration-office/28778.article?tab=contacts
+Bourne Registration Office	South Kesteven Community Point & Library, Bourne Corn Exchange	3 Abbey Road	Bourne	PE10 9EF	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/bourne-registration-office/28778.article
+Bournemouth Register Office	Town Hall	Bourne Avenue	Bournemouth	BH2 6DY	http://www.bournemouth.gov.uk/BirthsDeathsMarriages/BirthsDeathsMarriages.aspx
+Bracknell Forest Register Office	Time Square	Market Street	Bracknell	RG12 1JD	http://www.bracknell-forest.gov.uk/organisingaweddingwithbracknellforestregisteroffice
+Braintree Registration Office	Braintree Library	Fairfield Road	Braintree	CM7 3YL	https://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Brecon Registration Office	Neuadd Brycheiniog	Cambrian Way		LD3 7HR	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Brent Register Office	Brent Civic Centre	Engineers Way	Wembley	HA9 0FJ	http://brent.gov.uk/services-for-residents/births-marriages-and-deaths/ceremony-venues/brent-civic-centre/
+Brent Register Office	Brent Town Hall, Forty Lane	Wembley	Middlesex	HA9 9HD	https://www.brent.gov.uk/services-for-residents/births-marriages-and-deaths/contact-us/
+Brentwood Registration Office	Town Hall	Ingrave Road	Brentwood	CM15 8AY	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Bridgend Register Office	Ty'r Ardd	Sunnyside	Bridgend	CF31 4AR	http://www1.bridgend.gov.uk/services/registrars.aspx
+Bridgend Register Office	Helig Fan, Kenfig Hill	Bridgend	Mid Glamorgan	CF33 6BS	http://www1.bridgend.gov.uk/services/registrars.aspx
+Bridgwater Registration Office	Morgan House	Mount Street	Bridgwater	TA6 3ER	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Bridlington Registration Office	The Town Hall	Bridlington	East Riding of Yorkshire	YO16 4LP	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Bridport Registration Office	Mountfield	Rax Lane	Bridport	DT6 3JP	http://www.dorsetforyou.com/374462
+Brighton Register Office	Brighton Town Hall	Bartholomews	Brighton	BN1 1JA	http://www.brighton-hove.gov.uk/index.cfm?request=b1113986
+Bristol Register Office	The Old Council House	Corn Street	Bristol	BS1 1JG	https://www.bristol.gov.uk/births-deaths-marriages
+Broadstairs Library Register Office	Broadstairs Library 	The Broadway	Broadstairs	CT10 2BS	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?lid=83&uprn=100062281548
+Bromley Register Office	Civic Centre	Stockwell Close	Bromley	BR1 3UH	http://www.bromley.gov.uk/a_to_z/service/28/register_office
+Bromsgrove Register Office	School Drive	Bromsgrove	Worcestershire	B60 1AY	http://www.worcestershire.gov.uk/info/20000/births_deaths_marriages_and_citizenship
+Broxbourne Registration Office	Bishops College	Churchgate	Cheshunt	EN8 9XH	http://www.hertsdirect.org/your-community/register/contactreg/broxbournereg
+Buckinghamshire Register Office	County Hall	Walton Street	Aylesbury	HP20 1XF	http://www.buckscc.gov.uk/community/births,-deaths,-marriages-and-civil-partnerships/register-offices/aylesbury/
+Buckley Register Office	Buckley Town Hall	Mold Road	Buckley	CH7 2JB	http://www.flintshire.gov.uk/en/Resident/Registration-Service/Registration-Service.aspx
+Bude Registration Office	Bude Visitor Centre	The Crescent	Bude	EX23 8LE	http://www.cornwall.gov.uk/Default.aspx?page=14492
+Builth Wells Registration Office	Antur Gwy	Park Road		LD2 3BA	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Burgess Hill Registration Office	96 Church Walk	Burgess Hill		RH15 9AS	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Burnham-on-Sea Registration Office	The Old Court House	Jaycroft Road	Burnham-on-Sea	TA8 1EH	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Burnley Registration Office	Lyndhurst House	Todmorden Road	Burnley	BB10 4AB	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/burnley-registration-office.aspx
+Burton Registration Office	57-60 High Street	Burton upon Trent		DE14 1JS	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/burton/Burton-Registration-Office.aspx
+Burton Registration Office	Burton Library	Riverside	Burton upon Trent	DE14 1AH	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/burton/Burton-Registration-Office.aspx
+Bury Register Office	Town Hall, Knowsley Street	Bury	Lancashire	BL9 0SW	http://www.bury.gov.uk/index.aspx?articleid=10392
+Bury St Edmunds Register Office	7 Angel Hill	Bury St Edmunds		IP33 1UZ	https://www.suffolk.gov.uk/births-deaths-and-ceremonies/contact-a-register-office/
+Buxton Register Office	Town Hall	Market Place	Buxton	SK17 6EL	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Caernarfon Register Office	Gwynedd Council s Headquarters, Castle Street	Penrallt	Caernarfon	LL55 1SE	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Caerphilly Register Office	Penallta House, Tredomen Park	Ystrad Mynach	Hengoed	CF82 7PG	http://www.caerphilly.gov.uk/Services/Births,-marriages,-deaths/Register-office-opening-times
+Caistor Registration Office	Southdale	Area Council Offices	Caistor	LN7 6LX	http://www.lincolnshire.gov.uk/residents/births-marriages-deaths-and-civil-partnerships/registration-offices/bourne-registration-office/28778.article?tab=contacts
+Calderdale Register Office	Spring Hall	Huddersfield Road	Halifax	HX3 0AQ	http://www.calderdale.gov.uk/advice/births-marriages-deaths/index.html
+Calne Register Office	The Health Centre	Broken Cross	Calne	SN11 8RN	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Camberley Register Office 	Surrey Heath House (next to the museum) 	Knoll Road 	Camberley	GU15 3HD	http://www.surreycc.gov.uk/people-and-community/birth-death-marriage-and-civil-partnerships/surrey-register-offices/camberley-registrars-office
+Camborne Registration Office	Jayne Hooper House	Roaskear	Camborne	TR14 8DN	http://www.cornwall.gov.uk/Default.aspx?page=14493
+Cambridge Registration Office	Castle Lodge	Shire Hall	Cambridge	CB3 0AP	http://www.cambridgeshire.gov.uk/directory_record/2574/cambridge_office/
+Camden Register Office	Camden Town Hall	Judd Street	London	WC1H 9JE	http://www.camden.gov.uk/ccm/content/contacts/council-contacts/community-and-living/contact-register-office-services.en
+Cannock Registration Office	5 Victoria Street	Cannock		WS11 1BG	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/cannock/Cannock-Registration-Office.aspx
+Cannock Registration Office	5 Victoria Street	Cannock		WS11 1AG	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/cannock/Cannock-Registration-Office.aspx
+Canterbury Library Register Office	Canterbury Library 	18 High Street	Canterbury	CT1 2RA	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=8&uprn=010033173051
+Canterbury Register Office	Wellington House	St Stephens Road	Canterbury	CT2 7RD	http://www.akentishceremony.com/kcc-register-offices/
+Cardiff Register Office	City Hall (North West Entrance)	Cathays Park	Cardiff	CF10 3ND	https://www.cardiff.gov.uk/ENG/resident/Births-marriages-and-deaths/Cardiff-Register-Office/Pages/default.aspx
+Cardigan Registration Office	Morgan Street	Cardigan	Ceredigion	SA43 1DG	http://www.ceredigion.gov.uk/English/resident/Births-Deaths-Marriages-Civil-Partnerships/Pages/default.aspx
+Carlisle Registration Office	Lady Gillford s House	Petteril Bank Road	Carlisle	CA1 3AJ	http://www.cumbria.gov.uk/registrationservice/local_register_offices/carlisle.asp
+Carlton Register Office	Fairdale House, 47 Station Road	Carlton	Nottingham	NG4 3AR	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Carmarthen Register Office	Parc Myrddin	Richmond Terrace	Carmarthen	SA31 1HQ	http://www.carmarthenshire.gov.wales/home/residents/births-deaths-marriages/
+Castle Point Registration Office	Castle Point Borough Council Office, South Benfleet Library	264 High Road	South Benfleet 	CM15 8AY	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Central Bedfordshire Register Office	The Court House	Woburn Street	Ampthill	MK45 2HX	http://www.bedford.gov.uk/advice_and_benefits/registration_service.aspx
+Ceredigion Register Office	Canolfan Rheidol, Rhodfa Padarn	Llanbadarn Fawr	Aberystwyth	SY23 3UE	http://www.ceredigion.gov.uk/English/resident/Births-Deaths-Marriages-Civil-Partnerships/Pages/default.aspx
+Chapeltown Register Office	Reginald Centre	263 Chapeltown Road	Leeds	LS7 3EX	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Chard Registration Office	Holyrood Lace Mill	Holyrood Street	Chard	TA20 2YA	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Cheadle Registration Office	15a-17 High Street	Cheadle		ST10 1AA	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/cheadle/Cheadle-Office.aspx
+Chelmsford Registration Office	Chelmsford Library	Market Road	Chelmsford	CM1 1LH	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Cheltenham Register Office	Cheltenham Office, St Georges Road	Cheltenham	Glos	GL50 3EW	http://www.gloucestershire.gov.uk/registration
+Chepstow Sub Office	High Trees	Steep Street	Chepstow	NP16 5PJ	http://www.monmouthshire.gov.uk/research-your-family-history
+Chester Register Office	Goldsmith House	Goss Street	Chester	CH1 2BG	http://www.cheshirewestandchester.gov.uk/residents/births,_deaths_and_marriage/contact_and_opening_hours.aspx
+Chester-le-Street Register Office	Civic Centre	Chester-le-Street	County Durham	DH3 3UT	http://www.durham.gov.uk/registeroffices
+Chesterfield Registration Office	New Beetwell Street	Chesterfield		S40 1QJ	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Chichester - Edes House	Edes House	West Street	Chichester	PO19 1RQ	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Chichester Register Office	Record Office	3 Orchard Street	Chichester	PO19 1DD	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Chippenham Registration Office	4 Timber Street	Chippenham		SN15 3BZ	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Chorley Registration Office	Devonshire House	Devonshire Road	Chorley	PR7 2BY	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/chorley-registration-office.aspx
+Christchurch Registration Office	Civic Offices	Bridge Street	Christchurch	BH23 1AZ	http://www.dorsetforyou.com/374502
+Church Stretton Register Office	The Library/Customer First Point	Chiurch Street	Church Stretton	SY6 6DQ	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Cinderford Register Office	The Oaks, Belle Vue Centre	6 Belle Vue Road	Cinderford	GL14 2AB	http://www.gloucestershire.gov.uk/registration
+Cirencester Register Office	Cirencester Library	The Waterloo	Cirencester	GL7 2PZ	http://www.gloucestershire.gov.uk/registration
+Civic Centre	North Walk		Barnstaple	EX31 1EA	https://new.devon.gov.uk/registrationservice/registrationoffices/north-devon-registration-office
+Civic Centre	Ashby Road		Scunthorpe	DN16 1AB	http://www.northlincs.gov.uk/community-advice-and-support/births-deaths-and-marriages/births/register-a-birth/
+Clacton Registration Office	Clacton Library	96 Station Road	Clacton on Sea	CO15 1SF	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Clacton Registration Office	The Bungalow (opp Railway Station)	Clacton on Sea		CO15 6BP	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Cleethorpes Register Office	Cleethorpes Town Hall	Knoll Street	Cleethorpes	DN35 8LN	https://www.nelincs.gov.uk/resident/births-deaths-and-marriages/arranging-your-civil-ceremony/civil-ceremonies-register-office-grimsby/
+Clevedon Register Office	37a Old Church Road	Clevedon		BS21 6NN	http://www.birthsdeathsandmarriages.uk.com/component/mtree/Register%20a%20Birth/england/north-somerset/clevedon?Itemid=0
+Cliftonville Library Register Office	Cliftonville Library	Queen Elizabeth Avenue	Margate	CT9 3JX	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=84&uprn=100062307578
+Coalville Registration Service	41 Ravenstone Road	Coalville		LE67 3NB	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/stenson-house-coalville
+Cockermouth Register Office	Fairfield	Station Road	Cockermouth	CA13 9PT	http://www.cumbria.gov.uk/registrationservice/local_register_offices/cockermouth.asp
+Colchester Registration Office	Colchester Library	21 Trinity Square	Colchester	CO1 1JB	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Coldharbour Library Register Office	Coldharbour Library, Coldharbour Road	Northfleet	Gravesend	DA11 8AE	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=42&uprn=100062310918
+Consett Register Office	39 Medomsley Road	Consett	County Durham	DH8 5HE	http://www.durham.gov.uk/registeroffices
+Corby Register Office	Level 2 The Corby Cube, Parkland Gateway	George Street	Corby	NN17 1QG	http://www.northamptonshire.gov.uk/corbyregistrationoffice
+Cornwall Registration Office (Truro)	Dalvenie House	County Hall	Truro	TR1 3AY	http://www.cornwall.gov.uk/Default.aspx?page=14500
+Corsham Register Office	The Town Hall	High Street	Corsham	SN13 0EZ	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Cottingham Registration Office	Civic Centre	Market Green	East Riding of Yorkshire	HU16 5QG	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Council Offices	Castle Hill	Settle	Craven	BD24 9EU	http://www.northyorks.gov.uk/article/23006/Births-deaths-and-marriages
+Coventry Register Office	Cheylesmore Manor House	Manor House Drive	Coventry	CV1 2ND	http://www.coventry.gov.uk/info/321/death-registering/507/register_office
+Cranbook Library Register Office	Cranbook Library	Carriers Road	Cranbrook	TN17 3JT	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=100&uprn=010008666369
+Craven Arms Outstation	Shropshire Hills Discovery Centre	School Road	Craven Arms	SY7 9RS	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Crawley Register Office	West Sussex County Council	Southgate Avenue	Crawley	RH10 6HG	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Crewe Register Office	Municipal Buildings	Earle Street	Crewe	CW1 2BJ	http://www.cheshireeast.gov.uk/register_office/contact_details.aspx
+Criccieth Outstation	The Library	Council Office	Criccieth	LL52 0RN	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Crickhowell Registration Office	CRiC	Beaufort Street	Crickhowell	NP8 1BN	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Crook Register Office	Civic Centre	North Terrace	Crook	DL15 9ES	http://www.durham.gov.uk/registeroffices
+Crowborough Registration Office	Hookstead	Goldsmiths Avenue	Crowborough	TN6 1RH	https://new.eastsussex.gov.uk/community/registration/offices/crowborough
+Croydon Register Office	Croydon Town Hall, Ground Floor Offices	Fell Road	Croydon	CR0 1NX	https://www.croydon.gov.uk/community/births-deaths-marriage/marriage-civil-partnerships/register-office
+Customer Service Centre	Renfrewshire House	Cotton Street	Paisley	PA1 1AN	http://www.renfrewshire.gov.uk/webcontent/home/Services/BirthMarriageDeathsCivilPart/
+Customer Service Point	Library	Temperance Lane	Ystradgynlais	SA9 1JP	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Cwmbran Sub Office	1-2 General Rees Square	Cwmbran	Torfaen	NP44 1AH	http://www.torfaen.gov.uk/en/BirthsDeathsCeremonies/Registration-Opening-Hours-and-Locations/Hours-and-Locations.aspx
+Dacorum Registration Office	The Bury	Queensway	Hemel Hempstead	HP1 1HR	http://www.hertsdirect.org/your-community/register/contactreg/hemelreg
+Darlington Register Office	The Town Hall	Feethams	Darlington	DL1 5QT	http://www.darlington.gov.uk/Living/Register+Office/Register+Office.htm
+Dartford Library Register Office	Dartford Library, Central Park	Market Street	Dartford	DA1 1EU	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=14&uprn=200000533638
+Dartford Register Office	The Manor Gatehouse	Priory Road	Dartford	DA1 2BJ	http://www.akentishceremony.com/kcc-register-offices/
+Darwn Register Office	Town Hall	Croft Street	Darwen	BB3 2RN	https://www.blackburn.gov.uk/Pages/Register-offices.aspx
+Daventry Registration Office	Council Offices	Lodge Road	Daventry	NN11 4FP	http://www.northamptonshire.gov.uk/daventryregistrationoffice
+Deal Library Register Office	Deal Library	Broad Street	Deal	CT14 6ER	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=28&uprn=100062285653
+Deiniolen Outstation	The Library	T? Elidir	Deiniolen	LL55 3LA	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Denbigh Register Office	Eirianfa	Factory Place	Denbigh	LL16 3TS	https://www.denbighshire.gov.uk/en/resident/contact-us/visit-us/find-a-council-building-or-office/register-offices.aspx
+Denbighshire South Register Office	Ruthin Town Hall	Wynnstay Road	Ruthin	LL15 1YN	https://www.denbighshire.gov.uk/en/resident/contact-us/visit-us/find-a-council-building-or-office/register-offices.aspx
+Dereham Registration Office	Breckland Business Centre	St Withburga Lane	Dereham	NR19 1FD	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Devizes Registration Office	The Beeches	Bath Road	Devizes	SN10 2AL	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Devon Register Office	Olde Forde House	Brunel Road	Newton Abbot	TQ12 4XX	https://new.devon.gov.uk/registrationservice/registrationoffices/devon-register-office
+Dewsbury Register Office	Wellington Street	Dewsbury		WF13 1LY	http://www.kirklees.gov.uk/community/registrars/contacts.aspx
+Didcot Register Office	197 Broadway	Didcot		OX11 8RU	https://www.oxfordshire.gov.uk/cms/content/registration-offices
+Diss Registration Office	Council Offices	Market Hill	Diss	IP22 4JZ	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Dolgellau Register Office	Meirionnydd Area Office	Penarlag	Dolgellau	LL40 2YB	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Doncaster Register Office	Elmfield Park	South Parade	Doncaster	DN1 2EB	http://www.doncaster.gov.uk/services/births-marriages-deaths-nationality
+Dorchester Register Office	Dorset History Centre	Bridport Road	Dorchester	DT1 1RP	http://www.dorsetforyou.com/374526
+Dover Register Office	Dover Discovery Centre	Market Square	Dover	CT16 1PH	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=23&uprn=010034874734
+Downham Registration Office	15 Paradise Road	Downham Market	Norfolk	PE38 9HS	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Driffield Registration Office	West Garth	Mill Street	Driffield	YO25 6TP	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Droitwich Register Office	Droitwich Contact Centre	44 High Street	Droitwich Spa	WR9 8ES	http://www.wor...ces_directory
+Dudley Register Office	Priory Hall, Priory Park	Priory Road	Dudley	DY1 4EU	http://www.dudley.gov.uk/resident/living/registration-service/
+Dudley Register Office	Dudley Council Plus, Castle Street	Dudley	West Midlands	DY1 1LQ	http://www.dudley.gov.uk/resident/living/registration-service/
+Dukinfield Register Office	Dukinfield Town Hall	King Street	Dukinfield	SK16 4LA	http://www.tameside.gov.uk/registrars
+Dunmow Registration Office	Great Dunmow Library	47 White Hart Way	Dunmow	CM6 1FS	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Dunstable Register Office	Grove House	76 High Street North	Dunstable	LU6 1NF	http://www.centralbedfordshire.gov.uk/registration/landing.aspx
+Durham City Register Office	40 Old Elvet	Durham City		DH1 3HN	http://www.durham.gov.uk/registeroffices
+Ealing Register Office	Ealing Town Hall	New Broadway	London	W5 2BY	https://www.ealing.gov.uk/info/201034/births_deaths_marriages/751/contact_us
+East Devon Business Centre	Heathpark Way	Heathpark	Honiton	EX14 1SF	https://new.devon.gov.uk/registrationservice/registrationoffices/east-devon-registration-office-honiton
+East Grinstead Register Office	County Library	West Street	East Grinstead	RH19 4EY	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+East Leake Parish Council Offices	45 Main Street	East Leake	Loughborough	LE12 6PF	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Eastleigh Library Register Office	Eastleigh Library	1st Floor Swan Centre	Eastleigh	SO50 5SF	http://www3.hants.gov.uk/registration/registrationfinder/ro-eastleigh.htm
+Eastwood Register Office	Eastwood Health Clinic, Nottingham Road	Eastwood	Nottingham	NG16 3GL	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Eastwood Registration Office	D H Lawrence Heritage Centre, Mansfield Road	Eastwood	Nottingham	NG16 3DZ	http://www.nottinghamshire.gov.uk/births-deaths-marriages-and-civil-partnerships/register-offices-and-fees/nottinghamshire-register-offices/eastwood-registration-office
+Ellesmere Port Library Register Office	Ellesmere Port Library, 1st Floor	Civic way	Ellesmere Port	CH65 0BG	http://www.cheshirewestandchester.gov.uk/residents/births,_deaths_and_marriage/contact_and_opening_hours.aspx
+Ely Registration Office	Old School House	74 Market Street	Ely	CB7 4LS	http://www.cambridgeshire.gov.uk/directory_record/2572/ely_office/
+Enfield Register Office	1 Gentlemans Row	Enfield		EN2 6PS	http://www.enfield.gov.uk/info/200066/registration_ceremonies_and_cemeteries/819/register_office-contact_us
+Epping Registration Office	Epping Library	St John Road	Epping	CM16 5DN	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Evenbridge Register Office	The Eden Centre	Four Elms Road	Edenbridge	TN8 6BY	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=63&uprn=010013772382
+Evesham Register Office	Oat Street	Evesham	Worcestershire	WR11 4PJ	http://www.wor...ces_directory
+Exeter Register Office	Larkbeare House	Topsham Road	Exeter	EX2 4NG	https://new.devon.gov.uk/registrationservice/registrationoffices/exeter-registration-office
+Exmouth Register Office	Exmouth Town Hall	St Andrews Road	Exmouth	EX8 1AW	https://new.devon.gov.uk/registrationservice/registrationoffices/east-devon-registration-office-exmouth
+Fakenham Registration Office	Fakenham Connect	Oak Street	Fakenham	NR21 9SR	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Falmouth Registration Office	Skol Goth	Albany Place	Falmouth	TR11 3BZ	http://www.cornwall.gov.uk/Default.aspx?page=14494
+Fareham Registration Office	4 Osborn Road South	Fareham		PO16 7DG	http://www3.hants.gov.uk/registration/registrationfinder/ro-fareham.htm
+Farnham Library Register Office	Farnham Library, Vernon House	28 West Street	Farnham	GU9 7DR	http://www.surreycc.gov.uk/people-and-community/birth-death-marriage-and-civil-partnerships/surrey-register-offices/farnham-registrars-office
+Faversham Library Register Office	Faversham Library	Newton Road	Faversham	ME13 8DY	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=76&uprn=100062380361
+Felixstowe Register Office	Town Hall	Felixstowe		IP11 2AG	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Ferndown Registration Office	King George V Pavilion	Peter Grant Way	Ferndown	BH22 9EN	http://www.dorsetforyou.com/374527
+Fleetwood Registration Office	New Central Library	North Albert Street	Fleetwood	FY7 6AJ	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/fleetwood-registration-office.aspx
+Flintshire Register Office	Llwynegrin Hall	Mold	Flintshire	CH7 6NR	http://www.flintshire.gov.uk/en/Resident/Registration-Service/Registration-Service.aspx
+Flintshire Register Office	Flint Council Offices	Chapel Street	Flintshire	CH6 5WA	http://www.flintshire.gov.uk/en/Resident/Registration-Service/Registration-Service.aspx
+Folkestone Library Register Office	Folkestone Library 	2 Grace Hill	Folkestone	CT20 1HD	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=32&uprn=50040690
+Frome Registration Office	5 King Street	Frome		BA11 1BH	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Gainsborough Registration Office	Richmond House	Morton Terrace	Gainsborough	DN21 2RJ	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/gainsborough-registration-office/28760.article
+Garforth Library and One Stop Centre	Lidget Lane	Garforth	Leeds	LS25 1EH	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Gateshead Register Office	Gateshead Council, Civic Centre	Regent Street	Gateshead	NE8 1HH	http://www.gateshead.gov.uk/People%20and%20Living/Births-Deaths-and-Marriages/Home.aspx
+Gillingham Registration Office	Gillingham Town Hall	School Road	Gillingham	SP8 4QR	http://www.dorsetforyou.com/374542
+Gipping & Hartismere Registration Office	Milton House	Milton Road South	Stowmarket	IP14 1EZ	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Glenfield Register Office	Anstey Frith House, County Hall	Leicester Road	Glenfield	LE3 8RN	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/anstey-frith-house-glenfield
+Glossop Register Office	51a/53 High Street East	Glossop		SK13 8PN	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Gloucester Register Office	Shire Hall	Westgate Street	Gloucester	GL1 2TG	http://www.gloucestershire.gov.uk/registration
+Goole Registration Office	Council Offices	Church Street	Goole	DN14 5BG	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Gosport Registration Office	Gosport Discovery Centre	High Street	Gosport	PO12 1BT	http://www3.hants.gov.uk/registration/registrationfinder/ro-gosport.htm
+Grantham Registration Office	Totemic House	Caunt Road, off Springfield Road 	Grantham	NG31 7FZ	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/grantham-registration-office/54379.article
+Grantham Registration Office	Springfield House	Springfield Road	Grantham	NG31 7BG	http://www.lincolnshire.gov.uk/residents/births-marriages-deaths-and-civil-partnerships/registration-offices/grantham-registration-office/54379.article?tab=contacts
+Gravesend Library Register Office	Gravesend Library	Windmill Street	Gravesend	DA12 1BE	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=41&uprn=100062311356
+Great Yarmouth Register Office	The Library	Tolhouse Street	Great Yarmouth	NR30 2SH	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Greenwich Register Office	Town Hall, Wellington Street	Woolwich	London	SE18 6PW	http://www.greenwich.gov.uk/Greenwich/CommunityLiving/BirthsDeathsMarriages/Marriages/ContactDetails
+Guildford Registration Office	Artington House	42 Portsmouth Road	Guildford	GU2 4DZ	http://www.surreycc.gov.uk/people-and-community/birth-death-marriage-and-civil-partnerships/surrey-register-offices/guildford-register-office
+Guildhall Register Office	The Guildhall	High Street	Bath	BA1 5AW	http://www.bathnes.gov.uk/communityandliving/Pages/localoffices.aspx
+Hackney Register Office	Hackney Service Centre	1 Hillman Street	Hackney	E8 1DY	http://www.hackney.gov.uk/births
+Halesworth Library Register Office	Halesworth Library	Bridge Street	Halesworth	IP19 8AD	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Halewood Register Office	Halewood One Stop Shop, The Halewood Centre	Halewood	Knowsley	L26 9UH	http://www.knowsley.gov.uk/residents/one-stop-shops.aspx
+Halstead Registration Office	Halstead Hospital	78 Hedingham Road	Halstead	CO9 2DL	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Hammersmith & Fulham Register Office	Hammersmith Town Hall	King Street	London	W6 9JU	http://www.lbhf.gov.uk/Directory/Community_and_Living/Birth_marriage_and_death/Homepage.asp
+Harehills Register Office	Compton Road Centre	Harehills Lane	Leeds	LS9 7BG	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Haringey Register Office	Civic Centre, High Road	Wood Green	London	N22 8LE	http://www.haringey.gov.uk//index/community_and_leisure/bdm.htm
+Harlech Outstation	The Library	Old Primary School	Harlech	LL46 2YB	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Harlow Registration Office	Harlow Central Library	Cross Street	Harlow	CM20 1HA	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Harrogate Register Office	Bilton House	31 Park Parade	Harrogate	HG1 5AG	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5656
+Harrow Register Office	Harrow Council, Civic Centre	Station Road	Harrow	HA1 2XY	http://www.harrow.gov.uk/location
+Hartlepool Register Office	Civic Centre	Victoria Road	Hartlepool	TS24 8BN	https://www.hartlepool.gov.uk/info/20002/births_marriages_and_deaths/457/register_office_information
+Harwich Registration Office	Harwich Library	33-35 Kingsway, Dovercourt	Harwich	CO12 3JT	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Hastings Registration Office	Hastings Town Hall	Queens Road	Hastings	TN34 1QR	https://new.eastsussex.gov.uk/community/registration/offices/hastings
+Havant Plaza	Civic Centre Road	Havant		PO9 2AX	http://www3.hants.gov.uk/registration/registrationfinder/ro-havantplaza.htm
+Havant Registration Office	1st Floor Havant Library	Meridian Centre	Havant	PO9 1UN	http://www3.hants.gov.uk/registration/registrationfinder/ro-havant.htm
+Haverhill Library Register Office	Haverhill Library	Camps Road	Haverhill	CB9 8HB	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Havering Register Office	Langtons House	Billet Lane	Hornchurch	RM11 1XL	https://www.havering.gov.uk/Pages/Category/Contact-us.aspx
+Hay on Wye Registration Office	Council Offices	Broad Street	Hay on Wye	HR3 5BX	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Haywards Heath Library Register Office	Haywards Heath Library	34 Boltro Road	Haywards Heath	RH16 1BN	https://www.westsussex.gov.uk/location-directories/find-a-registration-office/details/api/type/registrationoffice/view/haywards-heath-registration-office
+Hedon Registration Office	The Customer Services Centre	2 New Road	Hedon	HU12 8EN	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Helston Registration Office	Isaac House	Tyacke Road	Helston	TR13 8RR	http://www.cornwall.gov.uk/Default.aspx?page=14495
+Henley Register Office	Easby House	Northfield End	Henley-on-Thames	RG9 2JN	https://www.oxfordshire.gov.uk/cms/content/registration-offices
+Herefordshire Register Office	Town Hall	St Owens Street	Hereford	HR1 2PJ	https://www.herefordshire.gov.uk/government-citizens-and-rights/registration/register-offices
+Herne Bay Library Register Office	Herne Bay Library 	124 High Street	Herne Bay	CT6 5JY	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=10&uprn=100062302754
+Hertford Registration Office	County Hall	Pegs Lane	Hertford	SG13 8DE	http://www.hertsdirect.org/your-community/register/contactreg/hertfordreg
+Hertfordshire Registration Office - Hatfield	19b St Albans Road East	Hatfield	Hertfordshire	AL10 0NG	http://www.hertsdirect.org/your-community/register/contactreg/hatfieldreg
+Hetton Centre Register Office	Welfare Road, Hetton-le-Hole	Houghton-le-Spring	Tyne and Wear	DH5 9NE	http://www.sunderland.gov.uk/index.aspx?articleid=2487
+Hexham Register Office	Hadrian House	Market Street	Hexham	NE46 3NH	http://www.northumberland.gov.uk/Registration.aspx
+High Peak Registration Office	Town Hall	New Mills	High Peak	SK22 4AT	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+High Wycome Library Register Office	High Wycome Library	5 Eden Place	High Wycombe	HP11 2DH	http://www.buckscc.gov.uk/community/births,-deaths,-marriages-and-civil-partnerships/register-offices/high-wycombe/
+Hillingdon Register Office	Civic Centre, High Street	Uxbridge	Middlesex	UB8 1UW	http://www.hillingdon.gov.uk/index.jsp?articleid=9657
+Hinckley Register Office	Atkins Building	Lower Bond Street	Hinckley	LE10 1QU	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/the-atkins-building-hinckley
+Holyhead Register Office	Holyhead Registration Office	Trearddur Square	Holyhead	LL65 1NB	https://www.anglesey.gov.uk/empty-nav/find-us/find-the-registry-office-llangefni/
+Holywell Library Register Office	Holywell Library, North Road	Holywell	Clwyd	CH8 7TQ	http://www.flintshire.gov.uk/en/Resident/Registration-Service/Registration-Service.aspx
+Horncastle Registration Office	Holmeleigh	Foundry Street	Horncastle	LN9 6AQ	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/horncastle-registration-office/28770.article
+Hornsea Registration Office	The Hornsea Resource Centre	Parva Road	Hornsea	HU18 1DW	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Horsham Registration Office	Park House	North Street	Horsham	RH12 9SB	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Houghton Library Register Office	74 Newbottle Street, Newbottle	Houghton-le-Spring	Tyne and Wear	DH4 4AF	http://www.sunderland.gov.uk/index.aspx?articleid=2487
+Hounslow Register Office	Feltham Lodge	Harlington Road West 	Feltham 	TW14 0JJ	http://www.hounslow.gov.uk/index/community_and_living/births.htm
+Hucknall Register Office	Under One Roof, 3A Vine Terrace	Hucknall	Nottingham	NG15 7HN	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Huddersfield Register Office	Huddersfield Town Hall	Ramsden Street	Huddersfield	HD1 2TA	http://www.kirklees.gov.uk/community/registrars/contacts.aspx
+Huyton Register Office	Archway Road	Huyton	Knowsley	L36 9YU	http://www.knowsley.gov.uk/residents/one-stop-shops.aspx
+Hythe Library Register Office	Hythe Library	1 Stade Street	Hythe	CT21 6BQ	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=35&uprn=50018994
+Ilkeston Registration Office	Town Hall	Wharncliffe Road 	Ilkeston	DE7 5RP	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Ipswich Register Office	St Peter House	16 Grimwade Street	Ipswich	IP4 1LP	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Isle of Wight Register Office	Seaclose Offices	Fairlee Road	Newport	PO30 2QS	https://www.iwight.com/Residents/Democratic-and-Registration-Services/Registration-of-Births-Deaths-Marriages-and-Civil/How-to-Register-a-Birth
+Isles of Scilly Register Office	Town Hall	St Marys	Isles of Scilly	TR21 0JZ	http://www.scilly.gov.uk/ceremonies-registration
+Islington Register Office	Islington Town Hall	Upper Street	London	N1 2UD	https://beta.islington.gov.uk/birth-death-marriage-and-citizenship/where-we-are-and-how-to-contact-us
+Johnstone Registration Office	16-18 McDowall Street	Johnstone		PA5 8QL	http://www.renfrewshire.gov.uk/webcontent/home/Services/BirthMarriageDeathsCivilPart/
+Kendal Register Office	County Offices	Busher Walk	Kendal	LA9 4RQ	http://www.cumbria.gov.uk/registrationservice/local_register_offices/kendal.asp
+Kensington and Chelsea Register Office	Chelsea Old Town Hall	Kings Road	London	SW3 5EE	https://www.rbkc.gov.uk/contactsdirectory/az.aspx?letter=K&orgid=1329
+Kettering Registration Office	Kettering Borough Council 	Bowling Green Road	Kettering	NN15 7QX	http://www.northamptonshire.gov.uk/ketteringregistrationoffice
+Kidderminster Registration Office	Council Offices	Bewdley Road	Kidderminster	DY11 6RL	http://www.wor...ces_directory
+Kidgrove Registration Office	Town Hall	Liverpool Road	Kidsgrove	ST7 4EH	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/kidsgrove/Kidsgrove-Office.aspx
+Kings Lynn Register Office	The Town Hall	Saturday Market Place	Kings Lynn	PE30 5DQ	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Kings Mill Hospital	Mansfield Road	Sutton in Ashfield		NG17 4JL	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Kingston upon Thames Register Office	Guildhall	High Street	Kingston Upon Thames	KT1 1EU	https://www.kingston.gov.uk/info/200131/births_deaths_marriages_and_citizenship/83/kingston_register_office
+Kingston-upon-Hull Register Office	The Wilson Centre Customer Service Centre Hull City Council 	Alfred Gelder StreetÃ‚Â 	HullÃ‚Â 	HU1 2AG	http://www.hullcc.gov.uk/portal/page?_pageid=221,52200&_dad=portal&_schema=PORTAL
+Kingswood Registration of Births & Deaths	Civic Centre, High Street	Kingswood	Bristol	BS15 9TR	https://www.southglos.gov.uk/community-and-living/
+Kirkby Register Office	Kirkby One Stop Shop	Cherryfield Drive	Knowsley	L32 1TX	http://www.knowsley.gov.uk/residents/one-stop-shops.aspx
+Knighton Registration Office	Offa's Dyke Heritage Centre	West Street		LD7 1EN	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Knowsley Register Office	High Street	Prescot		L34 3LD	http://www.knowsley.gov.uk/residents/births,-deaths-and-marriages/registering-a-birth
+Lambeth Register Office	Redfearn Centre	329 Kennington Lane	London	SE11 5QY	http://www.lambeth.gov.uk/places/lambeth-register-office
+Lampeter Registration Office	Market Street	Lampeter	Ceredigion	SA48 7DR	http://www.ceredigion.gov.uk/English/resident/Births-Deaths-Marriages-Civil-Partnerships/Pages/default.aspx
+Lancaster Registration Office	4 Queen Street	Lancaster		LA1 1RS	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/lancaster-registration-office.aspx
+Larkfield Register Office	Martin Square	Larkfield	Aylesford	ME20 6QW	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=95&uprn=100062389622
+Launceston Registration Office	Launceston Library	Bounsalls Lane	Launceston	PL15 9AB	http://www.cornwall.gov.uk/Default.aspx?page=14496
+Leamington Spa Registration Office	Riverside House	Milverton Hill	Leamington Spa	CV32 5HZ	http://www.warwickshire.gov.uk/registrationoffices
+Leatherhead Register Office	The Mansion	70 Church Street	Leatherhead	KT22 8DP	http://www.surreycc.gov.uk/people-and-community/birth-death-marriage-and-civil-partnerships/surrey-register-offices/leatherhead-register-office
+Leeds Register Office	2 Great George Street		Leeds	LS2 8BA	http://www.leeds.gov.uk/residents/Pages/Births-deaths-and-marriages.aspx
+Leek Registration Office	Moorlands District Council	Stockwell Street	Leek	ST13 6HQ	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/leek/Leek-Office.aspx
+Leicester Register Office	Town Hall	Town Hall Square	Leicester Road	LE1 9BG	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Leighton Buzzard Office	Bossard House	West Street	Leighton Buzzard	LU7 7DA	http://www.centralbedfordshire.gov.uk/registration/landing.aspx
+Lewes Registration Office	Southover Grange	Southover Road	Lewes	BN7 1TP	https://new.eastsussex.gov.uk/community/registration/offices/lewes
+Lewisham Register Office	368 Lewisham High Street	London		SE13 6LQ	https://www.lewisham.gov.uk/myservices/birthsdeathsmarriagesCP/Pages/default.aspx
+Leyburn Registration Office	Thornborough Hall	Leyburn	N Yorks	DL8 5AB	http://www.northyorks.gov.uk/article/23006/Births-deaths-and-marriages
+Lichfield Registration Office	The Old Library Building	Bird Street	Lichfield	WS13 6PN	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/lichfield/Lichfield-Registration-Office.aspx
+Lincoln Registration Office	4 Lindum Road	access from Danesgate	Lincoln	LN2 1NN	http://www.lincolnshire.gov.uk/residents/births-marriages-deaths-and-civil-partnerships/registration-offices/lincoln-register-office/28769.article?tab=contacts
+Liskeard Registration Office	Graylands	Dean Street	Liskeard	PL14 4AE	http://www.cornwall.gov.uk/Default.aspx?page=14497
+Littlehampton Registration Office	Arun Civic Centre	Maltravers Road	Littlehampton	BN17 5LF	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Liverpool Register Office	Heritage Entrance, St George s Hall	St George s Place	Liverpool	L1 1JJ	http://liverpool.gov.uk/births-marriage-deaths/
+Llanberis Outstation	The Library	Capel Coch Road	Llanberis	LL55 4SH	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Llandrindod Wells Registration Office	The Gwalia	Ithon Road	Llandrindod Wells	LD1 6AA	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Llandudno Register Office	Town Hall	Lloyd Street	Llandudno	LL30 2UP	http://www.conwy.gov.uk/doc.asp?cat=10035&doc=19535&Language=1
+Llanelli Registration Office	2 Coleshill Terrace	Llanelli		SA15 3DB	http://www.carmarthenshire.gov.wales/home/residents/births-deaths-marriages/
+Llanfyllin Registration Office	First Floor	Area Office	Llanfyllin	SY22 5BQ	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Llangefni Register Office	Shire Hall	Llangefni	Anglesey	LL77 7TW	https://www.anglesey.gov.uk/empty-nav/find-us/find-the-registry-office-llangefni/
+Llangollen Register Office	Capel Library	Castle Street	Llangollen	LL20 8NU	https://www.denbighshire.gov.uk/en/resident/contact-us/visit-us/find-a-council-building-or-office/register-offices.aspx
+Llanidloes Registration Office	Customer Service Point	Mount Lane	Llanidloes	SY18 6EY	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Long Eaton Registration Office	Long Eaton Sub Office, Town Hall	Derby Road	Long Eaton	NG10 1HU	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Long Sutton Registration Office	Swap Coat Lane	Long Sutton	Lincolnshire	PE12 9HB	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/long-sutton-registration-office/28781.article
+Loughborough Registration Service	Southfield Road	Loughborough		LE11 2TQ	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/charnwood-and-music-rooms-loughborough
+Loughborough Registration Service	202 Ashby Road	Loughborough		LE11 3AG	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/charnwood-and-music-rooms-loughborough
+Louth Registration Office	The Town Hall	Eastgate	Louth	LN11 9NH	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/louth-registration-office/28768.article
+Ludlow Register Office	Council Offices, Stone House	Corve Street	Ludlow	SY8 1DG	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Luton Register Office	6 George Street West	Luton	Bedfordshire	LU1 2BJ	https://www.luton.gov.uk/Community_and_living/register-office/Pages/default.aspx
+Lymington Library Register Office	Lymington Library	North Close	Lymington	SO41 9BW	http://www3.hants.gov.uk/registration/registrationfinder/ro-lymington.htm
+Lytham Registration Office	The Library	Clifton Street	Lytham	FY8 5EP	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/lytham-registration-office.aspx
+Macclesfield Registration Office	Town Hall Extension	Market Place	Macclesfield	SK10 1EA	http://www.cheshireeast.gov.uk/register_office/contact_details.aspx
+Machynlleth Registration Office	Y Plas	Aberystwyth		SY20 8ER	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Maesteg Register Office	Maesteg College, Castle Street	Maesteg	Mid Glamorgan	CF34 9UN	http://www1.bridgend.gov.uk/services/registrars.aspx
+Maidstone Register Office	The Archbishop's Palace	Mill Street	Maidstone	ME15 6YE	http://www.akentishceremony.com/kcc-register-offices/
+Maidstone Register Office	Kent History And Library Centre	James Whatman Way	Maidstone	ME14 1LQ	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=274&uprn=010014309203
+Maldon Registration Office	Carmelite House	White Horse Lane	Maldon	CM9 5FW	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Malmesbury Library Register Office	The Library	Cross Hayes	Malmesbury	SN16 9BG	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Malton Registration Office	Ryedale House	Old Malton Road	Malton	YO17 7HH	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5655
+Malvern Register Office	The Library/Contact Centre	Graham Road	Malvern	WR14 2HU	http://www.wor...ces_directory
+Manchester Register Office	Heron House	47 Lloyd Street	Manchester	M2 5LE	https://cms.manchester.gov.uk/site/scripts/documents_info.php?categoryID=321&documentID=1186
+Mansfield Register Office	County House, Dale Close	100 Chesterfield Road South	Mansfield	NG19 7AQ	http://www.nottinghamshire.gov.uk/births-deaths-marriages-and-civil-partnerships/register-offices-and-fees/nottinghamshire-register-offices/mansfield-registration-office
+Mansfield Register Office	County House, Dale Close	100 Chesterfield Road South	Mansfield	NG19 7DN	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+March Registration Office	Audmoor House	93 High Street	March	PE15 9LH	http://www.fenland.gov.uk/article/1746/Register-Office
+March Registration Office	Audmoor House	93 High Street	March	PE15 9LT	http://www.cambridgeshire.gov.uk/directory_record/2571/march_office/
+Market Drayton Register Office	Shropshire Customer First & Visitor Information Centre	49 Cheshire Street	Market Drayton	TF9 1PH	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Market Harborough Registration Service	42 Coventry Road	Market Harborough		LE16 9BZ	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/the-symington-building-market-harborough
+Marlborough Library Register Office	The Library	91 High Street	Marlborough	SN8 1HD	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Matlock Register Office	County Hall, Room 2	Smedley Street	Matlock	DE4 3AG	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Medway Register Office	Northgate	Rochester	Kent	ME1 1LS	http://www.medway.gov.uk/birthsceremoniesanddeaths.aspx
+Melksham Register Office	The Town Hall	Market Place	Melksham	SN12 6ES	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Melton Mowbray Registration Service	Areas Office	Leicester Road	Melton Mowbray	LE13 0DA	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/ferneley-room-melton-mowbray
+Melton Register Office	The Linos Centre, Saddlemakers Lane	Melton	Woodbridge	IP12 1PP	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Mere Library Register Office	The Library, Barton Lane	Church Street	Mere	BA12 6JA	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Merthyr Tydfil Register Office	Ty Penderyn	26 High Street	Merthyr Tydfil	CF47 8DP	http://www.merthyr.gov.uk/Home/Local+Services/Registrars+Births+Deaths+Marriages/Contact+Us.htm
+Merton Register Office	Morden Park House, Morden Park	London Road	Morden	SM4 5QU	http://www.merton.gov.uk/community-living/register/registeroffice.htm
+Middlesbrough Register Office	Town Hall	Albert Road	Middlesbrough	TS1 2PA	http://www.middlesbrough.gov.uk/?articleid=1653
+Midhurst Registration Office	The Grange	Bepton Road	Midhurst	GU29 9HD	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Midsomer Norton Register Office	The Hollies, High Street	Midsomer Norton	Radstock	BA3 2DT	http://www.bathnes.gov.uk/communityandliving/Pages/localoffices.aspx
+Milton Keynes Register Office	Bracknell House, Aylesbury Street	Bletchley	Milton Keynes	MK2 2BE	http://www.milton-keynes.gov.uk/registrars/
+Minehead Registration Office	1 Parkhouse Road	Minehead		TA24 8AA	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Monmouthshire Register Office	County Hall	Rhadyr	Usk	NP15 1GA	http://www.monmouthshire.gov.uk/research-your-family-history
+Moreton Library Register Office	Moreton Library	Stow Road	Moreton-in-Marsh	GL56 0DR	http://www.gloucestershire.gov.uk/registration
+Morley One Stop Centre	Town Hall, Queen Street	Morley	Leeds	LS27 9DY	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Morpeth Register Office	Morpeth Town Hall	Market Place	Morpeth	NE61 1LZ	http://www.northumberland.gov.uk/Registration.aspx
+Neath Register Office	119 London Road	Neath		SA11 1HL	http://www.npt.gov.uk/default.aspx?page=14690
+New Ollerton Register Office	Dukeries Complex	Whinney Lane	New Ollerton	NG22 9TH	http://www.nottinghamshire.gov.uk/births-deaths-marriages-and-civil-partnerships/register-offices-and-fees/nottinghamshire-register-offices
+Newark Register Office	County Council Offices	Balderton Gate	Newark	NG24 1UW	http://www.nottinghamshire.gov.uk/births-deaths-marriages-and-civil-partnerships/register-offices-and-fees/nottinghamshire-register-offices
+Newark Registration Office, The Gilstrap	Balderton Gate	Newark		NG24 1BG	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Newbury Register Office	Shaw House, Church Road	Shaw	Newbury	RG14 2DR	http://info.westberks.gov.uk/index.aspx?articleid=30243
+Newcastle Registration Office	20 Sidmouth Avenue	Newcastle under Lyme		ST5 0QN	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/newcastle/Newcastle-Registration-Office.aspx
+Newcastle Upon Tyne Register Office	Civic Centre	Newcastle Upon Tyne		NE1 8PS	https://www.newcastle.gov.uk/communities-and-neighbourhoods/births-deaths-and-marriages/contact-the-register-office
+Newham Register Office	207 Plashet Grove	East Ham	London	E6 1BT	https://www.newham.gov.uk/Pages/Services/Newham-Register-Office.aspx
+Newmarket Register Office	The Guineas Centre	63 The Guineas	Newmarket	CB8 8HT	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Newport Register Office	8 Gold Tops	Newport	South Wales	NP20 4PH	http://www.newport.gov.uk/_dc/index.cfm?fuseaction=registrars.homepage
+Newquay Registration Office	Lanherne House	Tolcarne Road	Newquay	TR7 2NQ	http://www.cornwall.gov.uk/advice-and-benefits/cornwall-registration-service/cornwall-registration-offices/newquay-registration-office/
+Newtown Registration Office	The Park Offices	Newtown		SY16 2NZ	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+North Allerton Registration Office	County Hall	North Allerton	Hambleton	DL7 8XE	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5662
+North Sefton Register Office	Corporation Street	Southport		PR8 1DA	http://sefton.gov.uk/births,-marriages-and-deaths/register-offices-in-sefton.aspx
+North Tyneside Register Office	Maritime Chambers	1 Howard Street	North Shields	NE30 1LZ	http://www.northtyneside.gov.uk/browse-display.shtml?p_ID=28311&p_subjectCategory=593
+North Walsham Registration Office	18 Kings Arms	North Walsham	Norfolk	NR28 9JX	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Northampton Registration Office	Northampton Central Library	Abington Street	Northampton	NN1 2BA	http://www.northamptonshire.gov.uk/northamptonregistrationoffice
+Northumberland Information Centre	Unit 10	Keel Row Shopping Centre	Blyth	NE24 1AH	http://www.northumberland.gov.uk/Registration.aspx
+Northwich Registration Office	Watling Street	Northwich		CW9 5ET	http://www.cheshirewestandchester.gov.uk/residents/births,_deaths_and_marriage/contact_and_opening_hours.aspx
+Nottingham Register Office	The Council House	Old Market Square	Nottingham	NG1 2DT	http://www.nottinghamcity.gov.uk/article/22738/Contact-the-Nottingham-Register-Office
+Nottinghamshire Register Office	Memorial Avenue	Workshop	Nottingham	S80 2BP	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Nuneaton Registration Office	Riversley Park	Coton Road	Nuneaton	CV11 5HA	http://www.warwickshire.gov.uk/registrationoffices
+Okehampton Register Office	Town Hall Offices	Fore Street	Okehampton	EX20 1AA	https://new.devon.gov.uk/registrationservice/registrationoffices/west-devon-registration-office-okehampton
+Old Heathcoat School Community Centre	King Street		Tiverton	EX16 5JJ	https://new.devon.gov.uk/registrationservice/registrationoffices/mid-devon-registration-office
+Oldham Register Office	Chadderton Town Hall, Middleton Road	Chadderton	Oldham	OL9 6PP	http://www.oldham.gov.uk/info/200194/venues/646/chadderton_town_hall
+Ollerton Registration Office	Dukeries Complex	Whinney Lane	New Ollerton	NG22 9TD	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+One 4 All Centre	Station Road	Treorchy		CF42 6NN	http://www.rctcbc.gov.uk/EN/Resident/BirthsMarriagesandDeaths/Familyhistorycertificatesandresearch/Registrarsrecordoffice.aspx
+One 4 All Centre	Rock Grounds	Aberdare		CF44 7AE	http://www.rctcbc.gov.uk/EN/Resident/BirthsMarriagesandDeaths/Familyhistorycertificatesandresearch/Registrarsrecordoffice.aspx
+Ormskirk Registration Office	Derby Street	Ormskirk		L39 2WS	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/ormskirk-registration-office.aspx
+Oswestry Register Office	Castle View	Oswestry		SY11 1JR	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Otley One Stop Shop Centre	8 Boroughgate	Otley	Leeds	LS21 3AH	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Oundle Library Registration Office	Oundle Library, Glapthorn Road	Oundle	Peterborough	PE8 4JA	http://www.northamptonshire.gov.uk/oundleregistrationoffice
+Oxford Register Office	1 Tidmarsh Lane	Oxford		OX1 1NS	https://www.oxfordshire.gov.uk/cms/content/registration-offices
+Pembrokeshire District Register Office	1 Cherry Grove, Haverfordwest	Dyfed	Pembrokeshire	SA61 2NZ	http://www.pembrokeshire.gov.uk/content.asp?nav=107,2213,2222
+Penarth Outstation	West House	Stanwell Road	Penarth	CF64 2YG	http://www.valeofglamorgan.gov.uk/en/living/life_in_the_community/registry_-_life_events/marriage_and_civil_partnership/contact_us.aspx
+Penrhyndeudraeth Outstation	The Library	Llys Deudraeth	Penrhyndeudraeth	LL48 6BL	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Penrith Register Office	Penrith Library	St Andrew`s Churchyard	Penrith	CA11 7YA	http://www.cumbria.gov.uk/registrationservice/local_register_offices/penrith.asp
+Penygroes Outstation	Adeilad y Clinig	Ffordd Buddug	Penygroes	LL54 6HD	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Penzance Registration Office	Alphington House	Alverton Place	Penzance	TR18 4JJ	http://www.cornwall.gov.uk/Default.aspx?page=14498
+Petersfield Registration Office	Petersfield Library	27 The Square	Petersfield	GU32 3HH	http://www3.hants.gov.uk/registration/registrationfinder/ro-petersfield.htm
+Plymouth Register Office	Lockyer Street	Plymouth		PL1 2QD	http://www.plymouth.gov.uk/homepage/communityandliving/marriageandpartnerships/civilpartnership/registeroffice.htm
+Pocklington Registration Office	Burnby Hall	Pocklington	East Riding of Yorkshire	YO42 2QF	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Pontefract Registration Office	Town Hall	Pontefract		WF8 1PG	http://www.wakefield.gov.uk/residents/community-and-housing/births-marriages-deaths
+Pontypool Register Office	Civic Centre	Pontypool	Torfaen	NP4 6YB	http://www.torfaen.gov.uk/en/BirthsDeathsCeremonies/Registration-Opening-Hours-and-Locations/Hours-and-Locations.aspx
+Pontypridd Register Office	Municipal Building	Gelliwastad Road	Pontypridd	CF37 2DP	http://www.rctcbc.gov.uk/EN/Resident/BirthsMarriagesandDeaths/Familyhistorycertificatesandresearch/Registrarsrecordoffice.aspx
+Poole Register Office	The Guildhall	Market Street	Poole	BH15 1NF	http://www.poole.gov.uk/communities-and-people/births-deaths-marriages-and-civil-partnerships/the-guildhall-registration/
+Portsmouth Register Office	Milldam House	Burnaby Road	Portsmouth	PO1 3AF	https://www.portsmouth.gov.uk/ext/health-and-care/registrars/registering-a-birth.aspx
+Preston Registration Office	Bow Lane	Preston		PR1 8SE	http://www.lancashire.gov.uk/births-marriages-and-deaths/find-a-registration-office/preston-registration-office.aspx
+Pudsey One Stop Centre	Town Hall, Robin Lane	Pudsey	Leeds	LS28 7BL	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Pwllheli Register Office	Dwyfor Area Office	Ffordd y Cob	Pwllheli	LL53 5AA	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Queens Hospital Burton Registration Office	Queens Hospital Burton	Belevdere Road	Burton on Trent	DE13 0RB	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/queens-hospital/Queens-Hospital-Burton.aspx
+Ramsgate Library Register Office	Ramsgate Library 	Guildford Lawn	Ramsgate	CT11 9AY	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=87&uprn=200002513204
+Ramsgate Register Office	Aberdeen House	68 Ellington Road	Ramsgate	CT11 9ST	http://www.akentishceremony.com/kcc-register-offices/
+Rawdon Council Offices	Micklefield House	Rawdon		LS19 6DF	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Rayleigh Registration Office 	Rayleigh Library	132-134 High Street	Rayleigh	SS6 7BX	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Reading Register Office	Yeomanry House	131 Castle Hill	Reading	RG1 7TA	http://www.reading.gov.uk/article/9145/Register-Office-directions
+Redbridge Register Office	Queen Victoria House	794 Cranbrook Road	Barkingside	IG6 1JS	http://www.redbridge.gov.uk/cms/contact_pages/r/register_office.aspx
+Redcar and Cleveland Register Office	Leisure and Community Heart	Ridley Street		TS10 1TD	http://www.redcar-cleveland.gov.uk/rcbcweb.nsf/web+full+list/83b0816617aefd7580257059004cabe2
+Redditch Registration Office	29 Easemore Road	Redditch	Worcestershire	B98 8ER	http://www.worcestershire.gov.uk/directory_record/1260/redditch_registration_office
+Registrars Office	Council Offices	Main Street	Mexborough	S64 9LU	http://www.doncaster.gov.uk/services/births-marriages-deaths-nationality
+Reigate Library Register Office	Reigate Library, Bancroft Road	Reigate	Surrey	RH2 7RP	http://www.surreycc.gov.uk/people-and-community/birth-death-marriage-and-civil-partnerships/surrey-register-offices/reigate-registrars-office
+Renfrew Registration Office	Renfrew Neighbourhood Office	14 Renfield Street	Renfrew	PA4 8RW	http://www.renfrewshire.gov.uk/webcontent/home/Services/BirthMarriageDeathsCivilPart/
+Retford Registration Office	County Council Offices	Chancery Lane	Retford	DN22 6DG	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Rhyl Register Office	Morfa Clwyd	Marsh Road	Rhyl	LL18 2AF	https://www.denbighshire.gov.uk/en/resident/contact-us/visit-us/find-a-council-building-or-office/register-offices.aspx
+Richmond Registration Office	12 Queens Road	Richmond	N Yorks	DL10 4AE	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5657
+Richmond upon Thames Register Office	York House	Richmond Road	Twickenham	TW1 3AA	http://www.richmond.gov.uk/home/services/registration_services/contact_registration_services.htm
+Ringwood Gateway Register Office	Ringwood Gateway	The Furlong	Ringwood	BH24 1AT	http://www3.hants.gov.uk/registration/registrationfinder/ro-ringwood.htm
+Rochdale Register Office	Town Hall	Vicars Gate	Rochdale	OL16 1AB	http://www.rochdale.gov.uk/births,_deaths_and_marriages.aspx
+Romsey Registration Office	1 Market Place		Romsey	SO518YZ	http://www3.hants.gov.uk/registration/registrationfinder/ro-romsey.htm
+Rothbury Register Office	Church House, Church Street	Rothbury	Morpeth	NE65 7UP	http://www.northumberland.gov.uk/Registration.aspx
+Rotherham Register Office	Riverside House	Main Street	Rotherham	S60 1AE	http://www.rotherham.gov.uk/births
+Rothwell Council Offices	Civic Building	Rothwell	Leeds	LS26 0AD	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Rugby Registration Office	5 Bloxam Place	Rugby		CV21 3DS	http://www.warwickshire.gov.uk/registrationoffices
+Runcorn Register Office	Runcorn Town Hall, Heath Road	Runcorn	Warrington	WA7 5TN	http://www4.halton.gov.uk/Pages/BirthsDeathsMarriages/BirthsDeathsMarriages.aspx
+Rushcliffe Registration Office, County Hall	Bridgford Road	West Bridgford	Nottingham	NG2 7QP	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Rutland Register Office	Catmose Cottage, South Street	Oakham	Rutland	LE15 6HY	http://www.rutland.gov.uk/council_and_democracy/births,_deaths,_marriages__ci.aspx
+Salford Register Office	Town Hall, Chorley Road	Swinton	Salford	M27 5DA	
+Salisbury Registration Office	Bourne Hill	Salisbury		SP1 3UZ	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Saltash Registration Office	Plougastel Centre	Plougastel Drive	Saltash	PL12 6DL	http://www.cornwall.gov.uk/Default.aspx?page=14499
+Sandwell Register Office	Highfields	High Street	West Bromwich	B70 8RJ	https://www.sandwell.gov.uk/registeroffice
+Sandwich Library Register Office	Sandwich Library 	13 Market Street	Sandwich	CT13 9DA	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=30&uprn=010034883329
+Saxmundham Register Office	County Offices	Street Farm Road	Saxmundham	IP17 1AL	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Scarborough Registration Office	North Cliff House	69 Burniston Road	Scarborough	YO12 6PH	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5663
+Selby Register Office	Civic Centre	Doncaster Road	Selby	YO8 9FT	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5660
+Sevenoaks Library Register Office	Sevenoaks Library 	Buckhurst Lane	Sevenoaks	TN13 1LQ	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=62&uprn=100062546713
+Shaftesbury Registration Office	Abbey View Medical Centre		Shaftesbury	SP7 8NU	http://www.dorsetforyou.com/374564
+Sheffield Register Office	Town Hall	Pinstone Street	Sheffield	S1 2HH	http://www.sheffield.gov.uk/your-city-council/register-office/register-office-contact-details
+Sheppey Register Office	Sheppey Gateway	38 - 42 High Street	Sheerness	ME12 1NL	http://www.swale.gov.uk/sheppey-gateway/
+Shepton Mallet Registration Office	19b Commercial Road	Shepton Mallet		BA4 5BU	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Sherborne Registration Office	Manor House	Newland	Sherborne	DT9 3JL	http://www.dorsetforyou.com/374565
+Shoreham-by-Sea Registration Office	Pond Road	Shoreham-by-Sea		BN43 5US	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Shropshire Council Area Headquarters - Bridgnorth	Westgate	Bridnorth		WV16 5AA	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Shropshire Register Office	The Shirehall	Abbey Foregate	Shrewsbury	SY2 6ND	http://www.shropshire.gov.uk/births,-deaths-and-marriages/book-an-appointment/registration-service-points/
+Sittingbourne Library Register Office	Sittingbourne Library 	Central Avenue	Sittingbourne	ME10 4AH	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=74&uprn=200002532058
+Sittingbourne Register Office  	Milton Place	Avenue of Remembrance	Sittingbourne	ME10 4DE	http://www.akentishceremony.com/kcc-register-offices/
+Skegness Registration Office	Aura Skegness Business Centre	Heath Road	Skegness	PE25 3SJ	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/skegness-registration-office/28773.article
+Skipton Registration Office	1 Belle Vue Square	Broughton Road	Skipton	BD23 1FJ	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5658
+Sleaford Registration Office	North Kesteven District Council Offices	Kesteven Street	Sleaford	NG34 7EF	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/sleaford-registration-office/28774.article
+Sleaford Registration Office	Council Offices	Eastgate	Sleaford	NG34 7EB	http://www.lincolnshire.gov.uk/residents/births-marriages-deaths-and-civil-partnerships/registration-offices/sleaford-registration-office/28774.article?tab=contacts
+Slough Register Office	The Curve, William Street	Slough	Berkshire	SL1 2JG	http://www.slough.gov.uk/births-marriage-deaths/register-a-death.aspx
+Solihull Register Office	Solihull Connect, Library Square	Touchwood	Solihull	B91 3RG	http://www.solihull.gov.uk/Resident/Births-deaths-marriages
+Solihull Register Office	West Mall, Chelmsley Wood Shopping Centre	Chelmsley Wood	Solihull	B37 5TN	http://www.solihull.gov.uk/Resident/Births-deaths-marriages
+Somerset Register Office (Taunton)	The Old Municipal Buildings	Corporation Street	Taunton	TA1 4AQ	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+South Derbyshire Registration Office	Council House	Corporation Street	Derby	DE1 2FS	http://www.derby.gov.uk/community-and-living/
+South Hams Registration Office	Follaton House	Plymouth Road	Totnes	TQ9 5NE	https://new.devon.gov.uk/registrationservice/registrationoffices/south-hams-registration-office
+South Sefton Register Office	Town Hall	Great Georges Road	Waterloo	L22 1RB	http://sefton.gov.uk/births,-marriages-and-deaths/register-offices-in-sefton.aspx
+South Wigston Registration Service	c/o Social Services Offices	Bassett Street	South Wigston	LE18 4PE	http://www.leicestershire.gov.uk/registrars/weddings-and-civil-partnerships/registration-offices-and-ceremony-rooms/south-wigston-registration-service
+Southampton Register Office	6a Bugle Street	Southampton		SO14 2LX	http://www.southampton.gov.uk/people-places/ceremonies/register-office.aspx
+Southend-on-Sea Register Office	Civic Centre, Victoria Avenue	Southend-on-Sea	Essex	SS2 6ER	http://www.southend.gov.uk/info/200213/births/161/registering_a_birth
+Southwark Register Office	34 Peckham Road	London		SE5 8QA	http://www.southwark.gov.uk/a_to_z/service/2013/southwark_register_office
+Southwell Registration Office	The Bramley Centre	King Street	Southwell	NG25 0EH	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Spalding Registration Office	Linden House	1 Bath Lane	Spalding	PE11 1XP	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/spalding-registration-office/28779.article
+St Albans Register Office	The Gatehouse, 1 Victoria Square	Victoria Street	St Albans	AL1 3TF	http://www.hertsdirect.org/your-community/register/contactreg/stalbansreg
+St Austell Registration Office	Polkyth House, Council Offices	12 Carlyon Road	St Austell	PL25 4LD	http://www.cornwall.gov.uk/Default.aspx?page=14501
+St Helens Register Office	Central Street	St Helens	Merseyside	WA10 1UJ	http://www.sthelens.gov.uk/what-we-do/births-deaths-and-marriages/
+Stafford Hospital Registration Office	Stafford Hospital	Weston Road	Stafford	ST16 3SA	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/stafford-hospital/Stafford-Hospital.aspx
+Stafford Registration Office	Stafford Office, Eastgate House	79 Eastgate Street	Stafford	ST16 2NG	http://www.staffordshire.gov.uk/community/lifeevents/homepage.aspx
+Stafford Registration Office	1 Staffordshire Place		Stafford	ST16 2LP	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/stafford/Stafford-Registration-Office.aspx
+Stamford Registration Office	2 St Marys Hill	Stamford	Lincolnshire	PE9 2DR	http://www.lincolnshire.gov.uk/residents/births-deaths-marriages-and-civil-partnerships/registration-offices/stamford-registration-office/29855.article
+Stanhope Register Office	Health Centre Dale Street	Stanhope	County Durham	DL13 2XD	http://www.durham.gov.uk/registeroffices
+Stanley Register Office	7 Thorneyholme Terrace	Stanley	County Durham	DH9 0BJ	http://www.durham.gov.uk/registeroffices
+Stapleford Library Registration Office	Stapleford Library, Church Street	Stapleford	Nottingham	NG9 8GA	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Stevenage Registration Office	Danesgate	Stevenage	Hertfordshire	SG1 1WW	http://www.hertsdirect.org/your-community/register/contactreg/stevenagereg
+Stockport Register Office	Town Hall	John Street Entrance	Stockport	SK1 3XE	http://www.stockport.gov.uk/services/communitypeopleliving/birthsmarriagesdeaths/stockportregisteroffice
+Stockton-on-Tees Register Office	Nightingale House	Balaclava Street	Stockton-on-Tees	TS18 2AL	https://www.stockton.gov.uk/stockton-council/births-deaths-marriages-and-civil-partnerships/register-office-location-and-opening-times/
+Stoke-on-Trent Register Office	Hanley Town Hall, Albion Street	Hanley	Stoke-on-Trent	ST1 1QQ	http://www.stoke.gov.uk/ccm/navigation/community-and-living/births-and-deaths/registration-service/
+Stoke-on-Trent Registration Office	Town Hall, High Street	Biddulph	Stoke-on-Trent	ST8 6AR	http://www.staffordshire.gov.uk/community/lifeevents/homepage.aspx
+Stone Registration Office	Mansion House Surgery	Abbey Street	Stone	ST15 8YE	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/offices.aspx
+Storrington Registration Office	Storrington Library	Ryecroft Lane	Storrington	RH20 4PA	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Stourbridge Register Office	Thomas Robinson Building, Cemetery Road	Stourbridge	West Midlands	DY9 8AN	http://www.dudley.gov.uk/resident/living/registration-service/
+Stratford upon Avon Registration Office	Winton House	Church Street	Stratford upon Avon	CV37 6HB	http://www.warwickshire.gov.uk/registrationoffices
+Stroud Register Office	Stroud Office, The Old Victorian School	Parliament Street	Stroud	GL5 1DY	http://www.gloucestershire.gov.uk/registration
+Sudbury Registration Office	The Town Hall	Old Market Place	Sudbury	CO10 1TL	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Sunderland Registration Service	Civic Centre	Sunderland		SR2 7DN	http://www.sunderland.gov.uk/index.aspx?articleid=2487
+Sutton Register Office	Russettings	25 Worcester Road	Sutton	SM2 6PR	https://www.sutton.gov.uk/info/200469/sutton_register_office
+Sutton-in-Ashfield Library Registration Office	Sutton-in-Ashfield Library	Idlewells Precinct	Sutton-in-Ashfield	NG17 1BP	http://www.nottinghamshire.gov.uk/living/life/births-marriages-and-deaths/register-offices/
+Swadlincote Register Office	Civic Way	Swadlincote		DE11 0AH	http://www.derbyshire.gov.uk/community/births_marriages_deaths/register_offices/default.asp
+Swanage Registration Office	The Town Hall	High Street	Swanage	BH19 2NZ	http://www.dorsetforyou.com/374567
+Swanley Library Register Office	Swanley Library 	London Road	Swanley	BR8 7AE	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=71&uprn=100062276749
+Swansea Register Office	Civic Centre (West access road)	Oystermouth Road	Swansea	SA1 3SN	http://www.swansea.gov.uk/index.cfm?articleid=1458
+Swindon Register Office	Civic Offices	Euclid Street	Swindon	SN1 2JH	http://www.swindon.gov.uk/info/20016/births_marriages_and_deaths/180/swindon_register_office
+Talgarth Registration Office	Library	New Street	Talgarth	LD3 0AH	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Tamworth Registration Office	Church Street	Tamworth		B79 7BX	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/tamworth/Tamworth-Registration-Office.aspx
+Tavistock Register Office	Council Offices	Kilworthy Park	Tavistock	PL19 0BZ	https://new.devon.gov.uk/registrationservice/registrationoffices/west-devon-registration-office-tavistock
+Tenbury Register Office	Library Contact Centre	24 Teme Street	Tenbury Wells	WR15 8AA	http://www.wor...ces_directory
+Tenterden Register Office	Tenterden Gateway, 2 Manor Row	High Street	Tenterden	TN30 6HP	http://www.tenterdentown.co.uk/index.php/community-and-living/local-groups/tenterden-gateway/
+Thameside Complex (Cromwell Road Entrance)	Orsett Road	Grays	Essex	RM17 5DX	http://www.thurrock.gov.uk/legal/register/
+Thanet Register Office	Thanet Gateway	Cecil Street	Margate	CT9 1RE	http://www.thanet.gov.uk/about-us/thanet-gateway-plus
+The Bradford and Keighley Register Office	City Hall	Centenary Sqaure	Bradford	BD1 1HY	http://www.bradford.gov.uk/bmdc/contact_us/contact_us_by_telephone/register_offices
+The Huntingdon Registration and Coroners Office	Lawrence Court	Princes Street	Huntingdon	PE29 3PA	http://www.cambridgeshire.gov.uk/directory_record/2573/huntingdon_office/
+The Norfolk Register office	The Archive Centre	Martineau Lane	Norwich	NR1 2DQ	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+The Talbot Centre	Whitchurch Business Park	Shakespeare Way	Whitchurch	SY13 1LJ	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+Thetford Registration Office	Kings House	King Street	Thetford	IP24 2AP	https://www.norfolk.gov.uk/births-ceremonies-and-deaths/registration-offices
+Tidworth Register Office	Memorial Health Centre	St Michael's Avenue	Tidworth	SP9 7EA	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Tonbridge Library Register Office	Tonbridge Library	1 Avebury Avenue	Tonbridge	TN9 1TG	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=89&uprn=100062593959
+Torbay Register Office	1st Floor, Cockington Court	Cockington	Torquay	TQ2 6XA	http://www.torbay.gov.uk/registeroffice
+Torridge Registration Office	Caddsdown Business Support Centre	Farm Road	Bideford	EX39 3DX	https://new.devon.gov.uk/registrationservice/registrationoffices/torridge-registration-office
+Totton Register Office	Totton Hub	1 High Street	Totton	SO40 9HL	http://www3.hants.gov.uk/registration/registration-contact/registration-totton.htm
+Towcester Registration Office	The Forum, Moat Lane	Towcester	Northants	NN12 6AD	http://www.northamptonshire.gov.uk/towcesterregistrationoffice
+Tower Hamlets Register Office	Bromley Public Hall	Bow Road	London	E3 3AA	http://www.towerhamlets.gov.uk/lgnl/advice_and_benefits/births,_marriages_and_deaths/opening_hours.aspx
+Trafford Register Office	Sale Town Hall	Sale Waterside	Sale	M33 7ZF	http://www.trafford.gov.uk/residents/births-marriages-and-deaths/births-marriages-and-deaths-registrars.aspx
+Trawsfynydd Outstation	Health Centre		Trawsfynydd	LL41 4TA	https://www.gwynedd.llyw.cymru/en/Residents/Births-marriages-deaths/Registry-offices.aspx
+Tredegar Register Office	Bedwellty House	Morgan Street	Tredegar	NP22 3XN	http://www.blaenau-gwent.gov.uk/advice/13826.asp
+Trowbridge Registration Office	The Chesnuts	Bythesea Road	Trowbridge	BA14 8EZ	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Tunbridge Wells Register Office	The Mansion House	Grove Hill Road	Tunbridge Wells	TN1 1EP	http://www.akentishceremony.com/kcc-register-offices/
+Tunbridge Wells Register Office	The Tunbridge Wells Gateway	8 Grosvenor Road	Tunbridge Wells	TN1 2AB	http://www.kent.gov.uk/community_and_living/births
+Tunbridge Wells Register Office	Tunbridge Wells Library 	Mount Pleasant Road	Royal Tunbridge Wells	TN1 1NS	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=99&uprn=100062541606
+Ulverston Register Office	The Town Hall	Ulverston		LA12 7AR	http://www.cumbria.gov.uk/registrationservice/local_register_offices/ulverston.asp
+Uttlesford Registration Office	Council Offices	London Road	Saffron Walden	CB11 4ER	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Uttoxeter Registration Office	Balance Street Surgery	Balance Street	Uttoxeter	ST14 8JG	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/uttoxeter/Uttoxeter-Office.aspx
+Uttoxeter Registration Office	Uttoxeter Library	Red Gables, 57 High Street	Uttoxeter	ST14 7JQ	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/uttoxeter/Uttoxeter-Office.aspx
+Vale of Glamorgan Register Office	Trinity Church, Saint Johns Drive	Porthcawl	The Vale of Glamorgan	CF36 3DT	http://www1.bridgend.gov.uk/services/registrars.aspx
+Vale of Glamorgan Register Office	Civic Offices	Holton Road	Barry	CF63 4RU	http://www.valeofglamorgan.gov.uk/en/living/life_in_the_community/registry_-_life_events/marriage_and_civil_partnership/contact_us.aspx
+Wakefield Register Office	Wakefield Town Hall	Wood Street	Wakefield	WF1 2HQ	http://www.wakefield.gov.uk/residents/community-and-housing/births-marriages-deaths
+Walsall Register Office	Walsall Council, Civic Centre	Hatherton Road	Walsall	WS1 1TN	http://cms.walsall.gov.uk/index/community_and_living/register-office.htm
+Waltham Forest Register Office	106 Grove Road	Walthamstow		E17 9BY	http://www.walthamforest.gov.uk/pages/services/register-office.aspx
+Wandsworth Register Office	Town Hall	High Street	Wandsworth	SW18 2PU	http://www.wandsworth.gov.uk/a_to_z/service/452/register_office
+Wareham Registration Office	The Library	South Street	Wareham	BH20 4LR	http://www.dorsetforyou.com/374568
+Warminster Register Office	The Library	Three Horseshoes Walk	Warminster	BA12 9BT	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Warrington Register Office	Museum Street	Warrington		WA1 1JX	https://www.warrington.gov.uk/info/201091/births_deaths_marriage/1244/warrington_register_office
+Warwick Registration Office	Shire Hall	Warwick		CV34 4RR	http://www.warwickshire.gov.uk/registrationoffices
+Washington Customer Service Centre and Library Register Office	Independence Square, Washington Centre	Washington	Tyne and Wear	NE38 7RZ	http://www.sunderland.gov.uk/index.aspx?articleid=2487
+Watford Registration Office	36 Clarendon Road	Watford	Hertfordshire	WD17 1JQ	http://www.hertsdirect.org/your-community/register/contactreg/watfordreg
+Watford Registration Office	31 Hempstead Road	Watford	Hertfordshire	WD17 3EY	http://www.hertsdirect.org/your-community/register/contactreg/watfordreg
+Waveney Registration Office	Gordon Road	Lowestoft		NR32 1JQ	http://www.suffolk.gov.uk/BirthsMarriagesAndDeaths/SuffolkRegistrationOffices/
+Wellingborough Registration Office	Council Offices	Swanspool House	Wellingborough	NN8 1BP	http://www.northamptonshire.gov.uk/wellingboroughregistrationoffice
+Wellington Registration Office	Somerset Skills and Learning	Corams Lane	Wellington	TA21 8LL	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Wells Registration Office	Town Hall	Market Place	Wells	BA5 2RB	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Welshpool Registration Office	Neuadd Maldwyn	Severn Road	Welshpool	SY21 7AS	http://www.powys.gov.uk/en/registrars/find-registry-offices-opening-times/
+Wem Register Office	Edinburgh House	New Street	Wem	SY4 5DB	http://www.shropshire.gov.uk/registrar.nsf/open/4F3206F3069D0B7780256D1E004B347D
+West Bridgford Registration Office	The Hall, Bridgford Road	West Bridgford	Nottingham	NG2 6AT	http://www.nottinghamshire.gov.uk/births-deaths-marriages-and-civil-partnerships/register-offices-and-fees/nottinghamshire-register-offices/west-bridgford-registration-office
+Westbury Community Hospital Register Office	Westbury Community Hospital	Westbury		BA13 3EL	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Westminster Register Office	Westminster City Hall	64 Victoria Street	London	SW1E 6QP	https://www.westminster.gov.uk/contact-westminster-register-office
+Weston-super-Mare Register Office	The Register Office	41 Boulevard	Weston-super-Mare	BS23 1PG	http://www.birthsdeathsandmarriages.uk.com/component/mtree/registering-a-death/england/avon/weston-super-mare?Itemid=0
+Wetherby Council Offices	24 Westgate	Wetherby	Leeds	LS22 6NL	http://www.leeds.gov.uk/docs/Registrars%20addresses%20and%20opening%20times.pdf
+Weybridge Register Office	Rylston	81 Oatlands Drive	Weybridge	KT13 9LN	http://www.surreycc.gov.uk/people-and-community/birth-death-marriage-and-civil-partnerships/surrey-register-offices/weybridge-register-office
+Weymouth Register Office	The Adult Learning Centre	45 Dorchester Road	Weymouth	DT4 7JT	http://www.dorsetforyou.com/374602
+Whitby Register Office	Farndale House, Church Square	Whitby	Scarborough	YO21 3EG	http://www.northyorks.gov.uk/article/23650/Registering-the-birth-of-your-baby?contactid=5659
+Whitehaven Register Office	College House	Flatt Walk	Whitehaven	CA28 7RW	http://www.cumbria.gov.uk/registrationservice/local_register_offices/whitehaven.asp
+Whitstable Library Register Office	Whitstable Library	Oxford Street	Whitstable	CT5 1DB	http://webapps.kent.gov.uk/KCC.Libraries.Web.Sites.Public/LibraryDetails.aspx?aid=0&lid=13&uprn=100062300410
+Wigton Library Registration Office	Wigton Library	High Street	Wigton	CA7 9NJ	http://www.cumbria.gov.uk/registrationservice/local_register_offices/wigton.asp
+Williton Registration Office	2 Long Street	Williton		TA4 4QN	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Wincanton Registration Office	The Community Office	Churchfields	Wincanton	BA9 9AG	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+Winchester Registration Office	Castle Hill	High Street	Winchester	SO23 8UH	http://www3.hants.gov.uk/registration/registrationfinder/ro-winchester.htm
+Windsor and Maidenhead Register Office	Town Hall	St Ives Road	Maidenhead	SL6 1RF	http://www3.rbwm.gov.uk/info/200154/births_deaths_and_ceremonies
+Winsford Library Register Office	Winsford Library	High Street	Winsford	CW7 2AS	http://www.cheshirewestandchester.gov.uk/residents/births,_deaths_and_marriage/contact_and_opening_hours.aspx
+Wisbech Registration Office	Fenland District Council One Stop Shop, Exchange Tower	2-3 Bridge St	Wisbech	PE13 1HG	http://www.cambridgeshire.gov.uk/directory_record/2570/wisbech_office/
+Witham Registration Office	Witham Library	18 Newland Street	Witham	CM8 2AQ	http://www.essex.gov.uk/Births%20Ceremonies%20Deaths/Births/Pages/Registration-Contacts.aspx
+Withernsea Registration Office	The Customer Services Centre	243 Queen Street	Withernsea	HU19 2HH	http://www2.eastriding.gov.uk/living/marriage-and-civil-partnerships/marriages/registration-office-finder/
+Witney Register Office	Council Offices	Woodgreen	Witney	OX28 1NB	https://www.oxfordshire.gov.uk/cms/content/registration-offices
+Wolverhampton Register Office	Wolverhampton City Council, Civic Centre	St Peters Square	Wolverhampton	WV1 1RU	https://www.wolverhampton.gov.uk/article/1745/Contact-births-marriages-deaths
+Wombourne Registration Office	Civic Centre	Gravel Hill	Wombourne	Wv5 9HA	http://www.staffordshire.gov.uk/community/lifeevents/marriage/venue-choice/offices/wombourne/Wombourne-Registration-Office.aspx
+Wootten Bassett Register Office	The Library 	Borough Fields 	Wootten Bassett	SN4 7AX	http://www.wiltshire.gov.uk/communityandliving/birthsdeathsmarriages/registrationservicelocationsopeningtimes.htm
+Worcester Register Office	County Hall	Spetchley Road	Worcester	WR5 2NP	http://www.wor...ces_directory
+Worcestershire Royal Hospital Register Office	Worcestershire Royal Hospital, Meadow Level	Charles Hastings Way	Worcester	WR5 1DD	http://www.wor...ces_directory
+Worthing Registration Office	Portland House	Richmond Road	Worthing	BN11 1HH	http://www.westsussex.gov.uk/living/births_marriages_and_deaths/registration_offices.aspx
+Wrexham Register Office	Ty Dewi Sant	Rhosddu Road	Wrexham	LL11 1NF	http://www.wrexham.gov.uk/english/life_events/bereavement/register_office.htm
+Wrexham Register Office	Caergwrle Clinic, Ty Cerrig	Caergwrle	Wrexham	LL12 9LF	http://www.flintshire.gov.uk/en/Resident/Registration-Service/Registration-Service.aspx
+Wychavon Council Offices	Queen Elizabeth Drive	Station Road	Pershore	WR10 1PT	http://www.wor...ces_directory
+Yeovil Registration Office	Maltravers House	Petters Way	Yeovil	BA20 1SP	http://www.somerset.gov.uk/births-marriages-deaths/registry-offices/
+York Register Office	56 Bootham	York		YO30 7DA	https://www.york.gov.uk/info/20026/births/1477/registering_a_birth


### PR DESCRIPTION
Add extract of data from gov.uk "Find a register office" service (https://www.gov.uk/register-offices).

List data was last updated 4 Jan 2017.

Fields are name, address1, address2, address3, postcode and url.